### PR TITLE
Change line length to 150

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -17,7 +17,7 @@
   "maxdepth" : 5,
   "maxstatements" : 50,
   "maxcomplexity" : 13,
-  "maxlen" : 120,
+  "maxlen" : 150,
   "browser" : true,
   "node" : true,
   "debug": true,


### PR DESCRIPTION
When try to build modeler with `grunt` an error is thrown

```
Running "jshint:src" (jshint) task
Linting app/index.js ...ERROR
[L96:C145] W101: Line is too long.
    if(dirty && !window.confirm('You made changes to the previous table, do you really want to load the new table and overwrite the changes?')) {
```
